### PR TITLE
Improve mobile header

### DIFF
--- a/prototype/about.html
+++ b/prototype/about.html
@@ -9,7 +9,8 @@
   <body>
     <header class="site-header">
       <div class="logo">Aries Restoration</div>
-      <nav>
+      <button class="menu-toggle" aria-controls="main-nav" aria-expanded="false">Menu</button>
+      <nav id="main-nav">
         <a href="index.html">Home</a>
         <a href="#services">Services</a>
         <a href="about.html">About</a>
@@ -28,8 +29,16 @@
         <img src="images/placeholder-team.svg" alt="prompt: group photo of professional restoration team" />
       </section>
     </main>
-    <footer>
-      <p>&copy; 2024 Aries Restoration</p>
-    </footer>
-  </body>
+  <footer>
+    <p>&copy; 2024 Aries Restoration</p>
+  </footer>
+  <script>
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.getElementById('main-nav');
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open);
+    });
+  </script>
+</body>
 </html>

--- a/prototype/contact.html
+++ b/prototype/contact.html
@@ -9,7 +9,8 @@
   <body>
     <header class="site-header">
       <div class="logo">Aries Restoration</div>
-      <nav>
+      <button class="menu-toggle" aria-controls="main-nav" aria-expanded="false">Menu</button>
+      <nav id="main-nav">
         <a href="index.html">Home</a>
         <a href="#services">Services</a>
         <a href="about.html">About</a>
@@ -32,8 +33,16 @@
         </form>
       </section>
     </main>
-    <footer>
-      <p>&copy; 2024 Aries Restoration</p>
-    </footer>
-  </body>
+  <footer>
+    <p>&copy; 2024 Aries Restoration</p>
+  </footer>
+  <script>
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.getElementById('main-nav');
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open);
+    });
+  </script>
+</body>
 </html>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -9,7 +9,8 @@
   <body>
     <header class="site-header">
       <div class="logo">Aries Restoration</div>
-      <nav>
+      <button class="menu-toggle" aria-controls="main-nav" aria-expanded="false">Menu</button>
+      <nav id="main-nav">
         <a href="index.html">Home</a>
         <a href="#services">Services</a>
         <a href="about.html">About</a>
@@ -59,8 +60,16 @@
         <a href="contact.html" class="btn-secondary">Request Help</a>
       </section>
     </main>
-    <footer>
-      <p>&copy; 2024 Aries Restoration</p>
-    </footer>
-  </body>
+  <footer>
+    <p>&copy; 2024 Aries Restoration</p>
+  </footer>
+  <script>
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.getElementById('main-nav');
+    toggle.addEventListener('click', () => {
+      const open = nav.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open);
+    });
+  </script>
+</body>
 </html>

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -98,3 +98,33 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 0.5em 1em;
+}
+
+@media (max-width: 600px) {
+  .menu-toggle {
+    display: block;
+  }
+  .site-header {
+    flex-wrap: wrap;
+    position: relative;
+  }
+  .site-header nav {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    background-color: #1E2A38;
+  }
+  .site-header nav.open {
+    display: flex;
+  }
+  .site-header nav a {
+    margin: 1em;
+  }
+}


### PR DESCRIPTION
## Summary
- make header responsive across prototype pages
- toggle menu for small screens
- add responsive header styles

## Testing
- `npx htmlhint "**/*.html"`

------
https://chatgpt.com/codex/tasks/task_e_685947320f7083308579652156bdb2ed